### PR TITLE
The current plugin is toggling the THEME, not dark mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,11 @@ class ToggleDarkModePlugin extends obsidian.Plugin {
 				id: 'toggle-dark-mode',
 				name: 'Toggle',
 				callback: () => {
-					this.app.changeTheme(this.app.getTheme() === 'obsidian' ? 'moonstone' : 'obsidian');
+					if (document.body.classList.contains('theme-dark')) {
+						this.app.commands.executeCommandById('theme:use-light')
+					} else {
+						this.app.commands.executeCommandById('theme:use-dark')
+					}
 				},
 			},
 		);


### PR DESCRIPTION
Here is how you toggle dark mode, rather than toggling between the two default themes.

The way it's currently coded won't work with themes other than default.